### PR TITLE
Update cossack link in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ license: MIT
 
 dependencies:
   cossack:
-    github: greyblake/crystal-cossack
+    github: crystal-community/cossack
     version: ~> 0.1
   string_converter:
     github: z64/string_converter


### PR DESCRIPTION
From `greyblake/crystal-cossack` to `crystal-community/cossack`
See https://github.com/greyblake/crystal-cossack/commit/5ac4b83876dde4583f2bb88c077c36fc8b2e5203